### PR TITLE
Added/enabled support for Actuators, primarily for health/info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/smartgridz/config/web/SpringSecurity.java
+++ b/src/main/java/com/smartgridz/config/web/SpringSecurity.java
@@ -49,6 +49,7 @@ public class SpringSecurity {
                                 .requestMatchers("/login").permitAll()
                                 .requestMatchers("/error").permitAll()
                                 .requestMatchers("/access_denied").permitAll()
+                                .requestMatchers("/actuator/**").permitAll()
                                 .requestMatchers("/**").authenticated()
                                 .and()
                 ).formLogin(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,3 +46,45 @@ logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.security.web.FilterChainProxy=DEBUG
 logging.level.org.springframework.web=DEBUG
 logging.level.root=ERROR
+
+############################################################################
+# Info Actuator:   http://localhost:8080/actuator/info
+info.app.company=SmartGridz
+info.app.name=Power Planner
+info.app.description="Simulation analysis and optimization software for enterprise energy operations."
+info.app.version=1.0.0
+
+############################################################################
+# Health Actuator:  http://localhost:8080/actuator/health
+#
+# health prints ok if the spring application is up and running.
+#
+############################################################################
+# Enable actuators: change this to '*' for everything or use a comma separated list e.g., health,info
+#
+# NOTE: this should be secured via SpringSecurity.java when initial dev work is complete.
+# NOTE: not all of these endpoints worked in testing, other packages need to be added to the pom.
+#
+# /auditevents lists security audit-related events such as user login/logout. Also, we can filter by principal or type among other fields.
+# /beans returns all available beans in our BeanFactory. Unlike /auditevents, it doesn't support filtering.
+# /conditions, formerly known as /autoconfig, builds a report of conditions around autoconfiguration.
+# /configprops allows us to fetch all @ConfigurationProperties beans.
+# /env returns the current environment properties. Additionally, we can retrieve single properties.
+# /flyway provides details about our Flyway database migrations.
+# /health summarizes the health status of our application.
+# /heapdump builds and returns a heap dump from the JVM used by our application.
+# /info returns general information. It might be custom data, build information or details about the latest commit.
+# /liquibase behaves like /flyway but for Liquibase.
+# /logfile returns ordinary application logs.
+# /loggers enables us to query and modify the logging level of our application.
+# /metrics details metrics of our application. This might include generic metrics as well as custom ones.
+# /prometheus returns metrics like the previous one, but formatted to work with a Prometheus server.
+# /scheduledtasks provides details about every scheduled task within our application.
+# /sessions lists HTTP sessions given we are using Spring Session.
+# /shutdown performs a graceful shutdown of the application.
+# /threaddump dumps the thread information of the underlying JVM.
+#
+management.endpoints.web.exposure.include=*
+############################################################################
+# Enable actuators
+management.info.env.enabled=true


### PR DESCRIPTION
Added Actuator support.  Primary use case is Health/Info.  Other endpoints may be interesting, threaddump,beans, etc...

punched a hole in security /actuator/**
documented in applications.properties
most endpoints run, several require additional spring-boot packages

![image](https://github.com/mrydeen/sample_app/assets/124785445/a73e6d53-9339-4b86-beb4-c7c65a136dee)
